### PR TITLE
Bugfix package name version fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Packages
 *.egg
+*.eggs/
 *.egg-info
 dist
 build

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,13 @@ the argument names mentioned under usage::
 
     blockage=true
     blockage-http-whitelist=some_site
-    blickage-smtp-whitelist=fake_smtp
+    blockage-smtp-whitelist=fake_smtp
+
+To store the settings in a setup.cfg or other ini style file::
+
+    [tool:pytest]
+    blockage=true
+    blockage-http-whitelist='some_site,othersite,last-site'
+    blockage-smtp-whitelist='smtp-server'
 
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,21 @@
+version: 0.2
+
+env:
+  variable:
+    PIP_REPO: 'pip.test.singleplatform.co'
+
+phases:
+  install:
+    commands:
+      - mkdir -p dist
+      - pip config set global.index-url https://$PIP_REPO/simple
+      - pip config set global.trusted-host $PIP_REPO
+      - pip config set global.extra-index-url https://pypi.python.org/simple
+  build:
+    commands:
+      - python setup.py check
+      - python setup.py test
+      - pip wheel --wheel-dir=dist .
+  post_build:
+    commands:
+      - piprepo sync dist s3://$PIP_REPO

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup
 
 
 setup(
-    name='sp-pytest-blockage',
-    version='0.2.1',
+    name='pytest-blockage',
+    version='0.3.0+singleplatform.1',
     description='Disable network requests during a test run.',
     long_description=(open('README.rst').read() +
                       open('CHANGELOG.rst').read()),

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,14 @@ from setuptools import setup
 
 setup(
     name='pytest-blockage',
+    url='https://github.com/singleplatform-eng/pytest-blockage',
     version='0.3.0+singleplatform.1',
     description='Disable network requests during a test run.',
     long_description=(open('README.rst').read() +
                       open('CHANGELOG.rst').read()),
     license='BSD',
+    author='SinglePlatform Engineering Team',
+    author_email='techservices@singleplatform.com',
     install_requires=['pytest'],
     py_modules=['pytest_blockage'],
     entry_points={'pytest11': ['blockage = pytest_blockage']},
@@ -17,5 +20,6 @@ setup(
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'Operating System :: OS Independent',
+        'Private :: Do Not Upload',
     ]
 )


### PR DESCRIPTION
This PR would revert the package name to pytest-blockage and add a +singleplatform local scheme to the package version. This keeps allows pip to manage version changes and keeps the package name in line with the module entry point. 

If there is a release for that tool in the future, we can use pip as an upgrade path:

```
Installing collected packages: pytest-blockage
  Found existing installation: pytest-blockage 0.2.0
    Uninstalling pytest-blockage-0.2.0:
      Successfully uninstalled pytest-blockage-0.2.0
Successfully installed pytest-blockage-0.3.0+singleplatform.1
```

Our current convention doesn't manage this upgrade path properly

```
 [wwalter@wwaltermac3 pytest-blockage (Bugfix_package_name_version_fix=) (none)]$ pip list | grep blockage
pytest-blockage                    0.3.0+singleplatform.1
sp-pytest-blockage                 0.2.1
You are using pip version 10.0.0, however version 10.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
[wwalter@wwaltermac3 pytest-blockage (Bugfix_package_name_version_fix=) (none)]$ pytest
============================================================================================================================= test session starts ==============================================================================================================================
platform darwin -- Python 2.7.14, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /Users/wwalter/work/pytest-blockage, inifile:
plugins: sp-pytest-blockage-0.2.1, cov-2.6.0, celery-4.2.0
collected 0 items

========================================================================================================================= no tests ran in 0.01 seconds ===================
```

In the above I am not positive what pytest_blockage.py module is being called. Uninstall either of the packages will break calls to pytest. 